### PR TITLE
Coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ branches:
 only:
 - master
 after_success:
-- mvn clean test
+- mvn clean test jacoco:report coveralls:report

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Spring Base64 Url Decoder
 =========================
 [![Build Status](https://api.travis-ci.org/ImmobilienScout24/spring-base64-url-decoder.svg?branch=master)](https://travis-ci.org/ImmobilienScout24/spring-base64-url-decoder)
+[![Coverage Status](https://img.shields.io/coveralls/ImmobilienScout24/spring-base64-url-decoder.svg?branch=master)](https://coveralls.io/r/ImmobilienScout24/spring-base64-url-decoder)
+
 
 This library delivers a annotation and adds a [HandlerMethodArgumentResolver] to the [Spring] MVC framework.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Spring Base64 Url Decoder
 =========================
 [![Build Status](https://api.travis-ci.org/ImmobilienScout24/spring-base64-url-decoder.svg?branch=master)](https://travis-ci.org/ImmobilienScout24/spring-base64-url-decoder)
 [![Coverage Status](https://img.shields.io/coveralls/ImmobilienScout24/spring-base64-url-decoder.svg?branch=master)](https://coveralls.io/r/ImmobilienScout24/spring-base64-url-decoder)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/de.is24.spring/base64-url-decoder/badge.svg)](https://maven-badges.herokuapp.com/maven-central/de.is24.spring/base64-url-decoder/)
 
 
 This library delivers a annotation and adds a [HandlerMethodArgumentResolver] to the [Spring] MVC framework.

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
 
   <properties>
     <spring.version>4.0.5.RELEASE</spring.version>
+    <jacoco.plugin.version>0.7.2.201409121644</jacoco.plugin.version>
+    <coveralls.plugin.version>3.0.1</coveralls.plugin.version>
   </properties>
   
   <build>
@@ -63,6 +65,24 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.4.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.eluder.coveralls</groupId>
+        <artifactId>coveralls-maven-plugin</artifactId>
+        <version>${coveralls.plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
introduces coveralls.io support for test coverage history and statistics as it's common on github. additionally adds link and image showing latest version on maven central.