### PR TITLE
Update Spring Framework to 5.3.31 to fix security vulnerability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>base64-url-decoder</artifactId>
   <version>1.3-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <name>Spring Base64 Url Decoder</name>
+  <n>Spring Base64 Url Decoder</n>
 
   <parent>
     <groupId>org.sonatype.oss</groupId>
@@ -14,13 +14,13 @@
   </parent>
   
   <organization>
-    <name>Immobilien Scout GmbH</name>
+    <n>Immobilien Scout GmbH</n>
     <url>http://www.immobilienscout24.de</url>
   </organization>
   <developers>
     <developer>
       <id>jrummler</id>
-      <name>Jens Rummler</name>
+      <n>Jens Rummler</n>
       <url>https://github.com/jrummler</url>
     </developer>
   </developers>
@@ -31,7 +31,7 @@
     <tag>HEAD</tag>
   </scm>
   <ciManagement>
-    <system>travis</system>
+    <s>travis</s>
     <url>https://travis-ci.org/ImmobilienScout24/spring-base64-url-decoder</url>
   </ciManagement>
 
@@ -39,13 +39,13 @@
   <url>https://github.com/ImmobilienScout24/spring-base64-url-decoder</url>
   <licenses>
     <license>
-      <name>MIT License</name>
+      <n>MIT License</n>
       <url>http://www.opensource.org/licenses/mit-license.php</url>
     </license>
   </licenses>
 
   <properties>
-    <spring.version>4.0.5.RELEASE</spring.version>
+    <spring.version>5.3.31</spring.version>
     <jacoco.plugin.version>0.7.2.201409121644</jacoco.plugin.version>
     <coveralls.plugin.version>3.0.1</coveralls.plugin.version>
   </properties>


### PR DESCRIPTION
## Description
This PR addresses the security vulnerability identified in SEC-16479 by updating the Spring Framework version from 4.0.5.RELEASE to 5.3.31.

### Changes
- Updated Spring Framework version from 4.0.5.RELEASE to 5.3.31 to address the unsafe Java deserialization vulnerability (GHSA-4wrc-f8pq-fpqp)
- Added Dependabot configuration to enable automated dependency updates in the future

### Testing
The project should be thoroughly tested after this update to ensure that everything still works with the new Spring version, as this is a major version upgrade (4.x to 5.x).

### References
- Related Jira ticket: SEC-16479
- GitHub Advisory: https://github.com/advisories/GHSA-4wrc-f8pq-fpqp
